### PR TITLE
Disable Eigen build testing by using populate mode to fix Androi buil…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,16 +9,14 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 add_executable(hello_methodverse src/main.cpp src/parameter.cpp)
 
 include(FetchContent)
-
 FetchContent_Declare(
     eigen
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
     GIT_TAG        3.4.0
 )
-set(EIGEN_BUILD_TESTING OFF CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(eigen)
+# Disable building of Eigen's tests, using populate instead of makeavailable.
+FetchContent_Populate(eigen)
 
-target_link_libraries(hello_methodverse PUBLIC Eigen3::Eigen)
 target_include_directories(hello_methodverse PUBLIC ${eigen_SOURCE_DIR})
 
 add_subdirectory(tst)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 
 add_executable(parameter_test parameter_test.cpp ../src/parameter.cpp)
-target_include_directories(parameter_test PRIVATE ${CMAKE_SOURCE_DIR}/include ${eigen_SOURCE_DIR}/Eigen)
-target_link_libraries(parameter_test gtest_main Eigen3::Eigen)
+target_include_directories(parameter_test PRIVATE ${CMAKE_SOURCE_DIR}/include ${eigen_SOURCE_DIR})
+target_link_libraries(parameter_test gtest_main)
 
 add_test(NAME parameter_test COMMAND parameter_test)


### PR DESCRIPTION
Use Eigen via Populate mode, and only include its headers in source code therefore no need to build and test it in cmake build process, which will cause an error in android build.